### PR TITLE
Repackage the saved app to start a penetration testing

### DIFF
--- a/androSecTest.go
+++ b/androSecTest.go
@@ -42,5 +42,6 @@ func main() {
 
 	dependency.AreAllReady()
 
-	androidpkg.Savelocal(args.AppName)
+	pkgname := androidpkg.Savelocal(args.AppName)
+	androidpkg.Setup(pkgname)
 }

--- a/androidpkg/repackage.go
+++ b/androidpkg/repackage.go
@@ -1,0 +1,136 @@
+package androidpkg
+
+import (
+	"github.com/shosta/androSecTest/command"
+	"github.com/shosta/androSecTest/command/adb"
+	"github.com/shosta/androSecTest/command/apktool"
+	"github.com/shosta/androSecTest/logging"
+	"github.com/shosta/androSecTest/variables"
+)
+
+func Setup(pkgname string) {
+	unzip(pkgname)
+	disassemble(pkgname)
+	mkdbg(pkgname)
+	allowbackup(pkgname)
+	rebuild(pkgname)
+	sign(pkgname)
+	reinstall(pkgname)
+}
+
+// Unzip the package to the 'unzippedPackage' Folder
+func unzip(pkgname string) {
+	var attacksDir string = variables.SecurityAssessmentRootDir + "/" + pkgname + variables.AttacksDir
+	var unzipDir string = attacksDir + variables.UnzippedPackageDir
+	logging.Println(logging.Green("Extract package : ") + logging.Bold(pkgname) + " to " + logging.Bold(unzipDir))
+
+	//var cmd string = "unzip " + attacksDir + variables.SourcePackageDir + "/" + pkgname + ".apk '*' -d " + unzipDir
+	cmdName := "unzip"
+	cmdArgs := []string{
+		attacksDir + variables.SourcePackageDir + "/" + pkgname + ".apk",
+		"-d",
+		unzipDir,
+	}
+	command.Run(cmdName, cmdArgs)
+
+	logging.Println(logging.Bold("Done"))
+}
+
+// Disassemble the package using the apktool that is installed on the system.
+func disassemble(pkgname string) {
+	logging.Println(logging.Green("Disassemble package : ") + logging.Bold(pkgname))
+
+	apktool.Disassemble(pkgname)
+
+	logging.Println(logging.Bold("Done"))
+}
+
+func mkdbg(pkgname string) {
+	logging.Println(logging.Green("Make package debuggable"))
+
+	var attacksDir string = variables.SecurityAssessmentRootDir + "/" + pkgname + variables.AttacksDir
+	var decodedDir string = attacksDir + variables.DecodedPackageDir
+	logging.PrintlnVerbose(logging.Green("Extract package : ") + logging.Bold(pkgname) + " to " + logging.Bold(decodedDir))
+
+	//cmd = "sed -i -e 's/<application /<application android:debuggable=\"true\" /' /tmp/Attacks/DecodedPackage/AndroidManifest.xml"
+	cmdName := "sed"
+	cmdArgs := []string{
+		"-i",
+		"-e",
+		"s/<application /<application android:debuggable=\"true\" /",
+		decodedDir + "/AndroidManifest.xml",
+	}
+	command.Run(cmdName, cmdArgs)
+
+	logging.Println(logging.Bold("Done"))
+}
+
+func allowbackup(pkgname string) {
+	logging.Println(logging.Green("Allow backup on package"))
+
+	var attacksDir string = variables.SecurityAssessmentRootDir + "/" + pkgname + variables.AttacksDir
+	var decodedDir string = attacksDir + variables.DecodedPackageDir
+
+	//cmd = "sed -i -e 's/android:allowBackup=\"false\" / /' /tmp/Attacks/DecodedPackage/AndroidManifest.xml"
+	cmdName := "sed"
+	cmdArgs := []string{
+		"-i",
+		"-e",
+		"s/android:allowBackup=\"false\" / /",
+		decodedDir + "/AndroidManifest.xml",
+	}
+	logging.PrintlnDebug("Remove the android:allowBackup=\"false\" if it is in the AndroidManifest.xml file.")
+	command.Run(cmdName, cmdArgs)
+
+	//cmd = "sed -i -e 's/<application /<application android:allowBackup=\"true\" /' /tmp/Attacks/DecodedPackage/AndroidManifest.xml"
+	cmdArgs = []string{
+		"-i",
+		"-e",
+		"s/<application /<application android:allowBackup=\"true\" /",
+		decodedDir + "/AndroidManifest.xml",
+	}
+	logging.PrintlnDebug("Add the android:allowBackup=\"true\" to the AndroidManifest.xml file.")
+	command.Run(cmdName, cmdArgs)
+
+	logging.Println(logging.Bold("Done"))
+}
+
+func rebuild(pkgname string) {
+	logging.Println(logging.Green("Rebuild package : ") + logging.Bold(pkgname))
+
+	apktool.Build(pkgname)
+
+	logging.Println(logging.Bold("Done"))
+}
+
+//signapk /tmp/Attacks/DebuggablePackage/" + package_name + ".b.apk"
+func sign(pkgname string) {
+	var pkgLoc string = variables.SecurityAssessmentRootDir + "/" + pkgname + variables.AttacksDir + variables.DebuggablePackageDir + "/" + pkgname
+	logging.PrintlnDebug("Package to sign : " + pkgLoc + ".b.apk")
+	//var cmd string = "java -jar /home/shosta/ShostaSyncBox/Developpement/HackingTools/SignApkUtils/sign.jar " + pkgLoc + "b.apk"
+
+	cmdArgs := []string{
+		"-jar",
+		"/home/shosta/ShostaSyncBox/Developpement/HackingTools/SignApkUtils/sign.jar",
+		pkgLoc + ".b.apk",
+	}
+	command.Run("java", cmdArgs)
+
+	// cmdArgs := []string{
+	// 	"-i",
+	// 	"-c",
+	// 	"signapk",
+	// 	pkgLoc + ".b.apk",
+	// }
+	// command.RunAlias("/bin/bash -i -c signapk " + pkgLoc + ".b.apk")
+	// command.RunCmd("bash -ic -rcfile ~/.bash_aliases signapk " + pkgLoc + ".b.apk")
+}
+
+//adb uninstall " + package_name
+//adb install /tmp/Attacks/DebuggablePackage/" + package_name + ".b.s.apk"
+func reinstall(pkgname string) {
+	adb.Uninstall(pkgname)
+
+	var localpkgPath string = variables.SecurityAssessmentRootDir + "/" + pkgname + variables.AttacksDir + variables.DebuggablePackageDir + "/" + pkgname + ".b.s.apk"
+	adb.Install(localpkgPath)
+}

--- a/command/apktool/apktool.go
+++ b/command/apktool/apktool.go
@@ -1,0 +1,64 @@
+package apktool
+
+import (
+	"fmt"
+	"os/exec"
+
+	"github.com/shosta/androSecTest/logging"
+	"github.com/shosta/androSecTest/variables"
+)
+
+func runApktool(args ...string) string {
+	cmd := exec.Command("apktool", args...)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		logging.PrintlnError(fmt.Sprint(err) + ": " + string(output))
+		return ""
+	}
+	return string(output)
+}
+
+// TODO Il faut prendre en compte les cas d'erreurs d'apktool.
+func Disassemble(pkgname string) string {
+	var attacksDir string = variables.SecurityAssessmentRootDir + "/" + pkgname + variables.AttacksDir
+	var sourcePkgDir string = attacksDir + variables.SourcePackageDir
+	var decodedDir string = attacksDir + variables.DecodedPackageDir
+
+	cmdArgs := []string{
+		"d",
+		sourcePkgDir + "/" + pkgname + ".apk",
+		"-f",
+		"-o",
+		decodedDir,
+	}
+
+	var output = runApktool(cmdArgs...)
+	logging.PrintlnVerbose(output)
+
+	logging.Println(logging.Green("Package disassembled with success") + " to " + logging.Bold(decodedDir))
+
+	return output
+}
+
+// TODO Il faut prendre en compte les cas d'erreurs d'apktool.
+//cmd = "apktool b /tmp/Attacks/DecodedPackage -o /tmp/Attacks/DebuggablePackage/" + package_name + ".b.apk"
+func Build(pkgname string) string {
+	var attacksDir string = variables.SecurityAssessmentRootDir + "/" + pkgname + variables.AttacksDir
+	var decodedDir string = attacksDir + variables.DecodedPackageDir
+	var debugPkgDir string = attacksDir + variables.DebuggablePackageDir
+
+	cmdArgs := []string{
+		"b",
+		decodedDir,
+		"-o",
+		debugPkgDir + "/" + pkgname + ".b.apk",
+	}
+
+	var output = runApktool(cmdArgs...)
+	logging.PrintlnVerbose(output)
+
+	logging.Println(logging.Green("Package built with success") + " to " + logging.Bold(debugPkgDir))
+
+	return output
+}

--- a/command/command.go
+++ b/command/command.go
@@ -1,0 +1,59 @@
+package command
+
+import (
+	"fmt"
+	"os/exec"
+
+	"github.com/shosta/androSecTest/logging"
+)
+
+func Run(command string, args []string) string {
+	cmd := exec.Command(command, args...)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		logging.PrintlnError(fmt.Sprint(err) + ": " + string(output))
+		return ""
+	}
+	return string(output)
+}
+
+func RunCmd(cmd string) string {
+	out, err := exec.Command(cmd).Output()
+	if err != nil {
+		logging.PrintlnError("error occured")
+		logging.PrintlnError(fmt.Sprint(err))
+	}
+	fmt.Printf("%s", out)
+
+	return string(out)
+}
+
+// func RunAlias(cmd string, args []string) string {
+// 	binary, lookErr := exec.LookPath("/bin/bash")
+// 	if lookErr != nil {
+// 		logging.PrintlnDebug("look")
+// 		panic(lookErr)
+// 	}
+
+// 	args2 := []string{"-c", "signapk", cmd}
+
+// 	env := os.Environ()
+
+// 	execErr := syscall.Exec(binary, args2, env)
+// 	if execErr != nil {
+// 		logging.PrintlnDebug("sys")
+// 		panic(execErr)
+// 	}
+
+// 	return "done"
+
+// 	testCmd := exec.Command("java", "-jar", "/home/shosta/ShostaSyncBox/Developpement/HackingTools/SignApkUtils/sign.jar", cmd+".apk")
+// 	testOut, err := testCmd.Output()
+// 	if err != nil {
+// 		panic(err)
+// 	}
+// 	fmt.Println(string(testOut))
+
+// 	return string(testOut)"
+// }


### PR DESCRIPTION
The package is unzipped to a specific folder.
Disassemble through apktool
Make debuggable
Allow backup on it
Repackage it,
Sign it
Uninstall app on the device
Reinstall the new app on the device.