### PR TITLE
Verify Android device connection prior to any analysis

### DIFF
--- a/androSecTest.go
+++ b/androSecTest.go
@@ -16,13 +16,13 @@ limitations under the License.
 package main
 
 import (
+	arg "github.com/alexflint/go-arg"
 	"github.com/shosta/androSecTest/androidpkg"
 	"github.com/shosta/androSecTest/attacks"
 	dependency "github.com/shosta/androSecTest/command/dependency"
+	"github.com/shosta/androSecTest/devices"
 	"github.com/shosta/androSecTest/logging"
 	"github.com/shosta/androSecTest/variables"
-
-	"github.com/alexflint/go-arg"
 )
 
 var args struct {
@@ -34,6 +34,11 @@ var args struct {
 
 func main() {
 	dependency.AreAllReady()
+
+	if !devices.IsConnected() {
+		logging.Println(logging.Green("No device is connected.") + "\nPlease " + logging.Bold("connect a device to your computer") + " prior to any penetration testing.")
+		return
+	}
 
 	arg.MustParse(&args)
 	pkgname := ""

--- a/command/adb/adb.go
+++ b/command/adb/adb.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// This program can be used as go_android_GOARCH_exec by the Go tool.
+// Package adb : This program can be used as go_android_GOARCH_exec by the Go tool.
 // It executes binaries on an android device using adb.
 package adb
 
@@ -25,7 +25,7 @@ func runAdb(args ...string) string {
 	return string(output)
 }
 
-// Pull
+// Pull :
 func Pull(pkgpath string, pkgdest string) string {
 	logging.PrintlnDebug(logging.Green("Package path : ") + logging.Bold(pkgpath))
 	logging.PrintlnDebug(logging.Green("Package destination : ") + logging.Bold(pkgdest))
@@ -40,7 +40,7 @@ func Pull(pkgpath string, pkgdest string) string {
 	return string(output)
 }
 
-// Get the path of the package name on the connected device on adb.
+// PkgPath : Get the path of the package name on the connected device on adb.
 // It returns the package's path on the device as a string.
 func PkgPath(pkgname string) string {
 	logging.PrintlnDebug(logging.Green("Package name: ") + pkgname)
@@ -54,6 +54,7 @@ func PkgPath(pkgname string) string {
 	return pkgpath
 }
 
+// ListPackages :
 func ListPackages(pkgnamepart string) []string {
 	logging.Println(logging.Green("Get the packages names") + " on the device that contains \"" + logging.Bold(pkgnamepart) + "\":")
 
@@ -64,7 +65,7 @@ func ListPackages(pkgnamepart string) []string {
 	return pkgs
 }
 
-//adb uninstall " + package_name
+//Uninstall : adb uninstall " + package_name
 func Uninstall(pkgname string) string {
 	logging.PrintlnDebug("Uninstall app on the device.")
 	out := runAdb("uninstall", pkgname)
@@ -72,11 +73,19 @@ func Uninstall(pkgname string) string {
 	return string(out)
 }
 
-//adb install /tmp/Attacks/DebuggablePackage/" + package_name + ".b.s.apk"
+//Install : adb install /tmp/Attacks/DebuggablePackage/" + package_name + ".b.s.apk"
 func Install(localpkgpath string) string {
 	logging.PrintlnDebug("Install app on the device.")
 	logging.PrintlnDebug("Local package path: " + localpkgpath)
 	out := runAdb("install", localpkgpath)
+
+	return string(out)
+}
+
+// Devices : List the devices connected to the computer.
+func Devices() string {
+	logging.PrintlnDebug("List devices connected to the computer.")
+	out := runAdb("devices", "-l")
 
 	return string(out)
 }

--- a/devices/connection.go
+++ b/devices/connection.go
@@ -1,0 +1,31 @@
+// Package devices : Check that a device is connected and adb commands can then be performed on it.
+package devices
+
+import (
+	"strings"
+
+	"github.com/shosta/androSecTest/command/adb"
+	"github.com/shosta/androSecTest/logging"
+)
+
+func connectedDevices(adbOutput string) []string {
+	devices := strings.Split(strings.TrimSpace(adbOutput), "List of devices attached")[1]
+	devicesArray := strings.Split(devices, "\n")
+
+	return devicesArray[1:len(devicesArray)]
+}
+
+// IsConnected : Check is a device is connected through USB to the computer and is ready to receive "adb" commands.
+// It uses the command : "adb devices -l" to verify it.
+func IsConnected() bool {
+	output := adb.Devices()
+	logging.PrintlnDebug("Devices : \n" + output)
+	devicesArray := connectedDevices(output)
+
+	if len(devicesArray) > 0 {
+		logging.PrintlnDebug("No device connected to the computer.")
+		return true
+	}
+
+	return false
+}


### PR DESCRIPTION
The program is listing the connected device prior to any analysis.
It quits the program if no device is connected to the computer.