### PR TITLE
Add 4 config files to handle the app build target const management 

### DIFF
--- a/androSecTest.go
+++ b/androSecTest.go
@@ -20,6 +20,7 @@ import (
 	"github.com/shosta/androSecTest/androidpkg"
 	"github.com/shosta/androSecTest/attacks"
 	dependency "github.com/shosta/androSecTest/command/dependency"
+	"github.com/shosta/androSecTest/config"
 	"github.com/shosta/androSecTest/devices"
 	"github.com/shosta/androSecTest/logging"
 )
@@ -50,7 +51,7 @@ func main() {
 	}
 
 	if args.Verbose {
-		variables.IsVerboseLogRequired = true
+		config.IsVerboseLogRequired = true
 	}
 
 	if args.Attacks == false {

--- a/androSecTest.go
+++ b/androSecTest.go
@@ -22,7 +22,6 @@ import (
 	dependency "github.com/shosta/androSecTest/command/dependency"
 	"github.com/shosta/androSecTest/devices"
 	"github.com/shosta/androSecTest/logging"
-	"github.com/shosta/androSecTest/variables"
 )
 
 var args struct {
@@ -54,7 +53,6 @@ func main() {
 		variables.IsVerboseLogRequired = true
 	}
 
-	variables.SecAssessmentPath = variables.SecAssessmentPath + "/" + pkgname + variables.AttacksDir
 	if args.Attacks == false {
 		androidpkg.Savelocal(pkgname)
 		androidpkg.Setup(pkgname)

--- a/androidpkg/save.go
+++ b/androidpkg/save.go
@@ -4,7 +4,6 @@ import (
 	"github.com/shosta/androSecTest/attacks"
 	"github.com/shosta/androSecTest/command/adb"
 	"github.com/shosta/androSecTest/logging"
-	"github.com/shosta/androSecTest/variables"
 )
 
 // Savelocal : Allow the user to select the package he wants to save locally on its computer through a simple part of the package name.
@@ -33,7 +32,7 @@ func path(pkgname string) string {
 
 // Pull a package on the connected devices via adb.
 func pull(pkgname string, pkgpath string) {
-	var destLocation = variables.SecurityAssessmentRootDir + "/" + pkgname + variables.AttacksDir + variables.SourcePackageDir + "/" + pkgname + ".apk"
+	destLocation := attacks.SourcePackageDirPath(pkgname) + "/" + pkgname + ".apk"
 	logging.Println(logging.Green("Pull package from ") + logging.Bold(pkgpath))
 
 	var out = adb.Pull(pkgpath, destLocation)

--- a/attacks/folders.go
+++ b/attacks/folders.go
@@ -3,6 +3,7 @@ package attacks
 import (
 	"os"
 
+	"github.com/shosta/androSecTest/config"
 	"github.com/shosta/androSecTest/logging"
 
 	"github.com/shosta/androSecTest/variables"
@@ -11,14 +12,14 @@ import (
 // The folder to start working on a package is : ~/android/security/'packagename'/attacks/...
 
 func createRootFolder() {
-	os.MkdirAll(variables.SecurityAssessmentRootDir, os.ModePerm)
+	os.MkdirAll(config.SecurityAssessmentRootDir, os.ModePerm)
 }
 
 // CreateAttacksFolder : Create the attack folder
 func CreateAttacksFolder(pkgname string) {
 	createRootFolder()
 
-	var pkgdir = variables.SecurityAssessmentRootDir + "/" + pkgname
+	var pkgdir = config.SecurityAssessmentRootDir + "/" + pkgname
 	os.MkdirAll(pkgdir, os.ModePerm)
 
 	os.MkdirAll(pkgdir+variables.AttacksDir+variables.SourcePackageDir, os.ModePerm)
@@ -41,37 +42,37 @@ func CreateAttacksFolder(pkgname string) {
 
 // InsecStorageDirPath : Return the Insecure Storage folder path.
 func InsecStorageDirPath(pkgname string) string {
-	return variables.SecurityAssessmentRootDir + "/" + pkgname + variables.AttacksDir + variables.InsecureStorageDir
+	return config.SecurityAssessmentRootDir + "/" + pkgname + variables.AttacksDir + variables.InsecureStorageDir
 }
 
 // InsecLoggingDirPath : Return the Insecure Logging folder path.
 func InsecLoggingDirPath(pkgname string) string {
-	return variables.SecurityAssessmentRootDir + "/" + pkgname + variables.AttacksDir + variables.InsecureLoggingDir
+	return config.SecurityAssessmentRootDir + "/" + pkgname + variables.AttacksDir + variables.InsecureLoggingDir
 }
 
 // UnzipDirPath : Return the folder path where we store the "unzip" command result files.
 func UnzipDirPath(pkgname string) string {
-	return variables.SecurityAssessmentRootDir + "/" + pkgname + variables.AttacksDir + variables.SourcePackageDir
+	return config.SecurityAssessmentRootDir + "/" + pkgname + variables.AttacksDir + variables.SourcePackageDir
 }
 
 // SourcePackageDirPath : Return the folder that contains the package we pulled initially from the device.
 func SourcePackageDirPath(pkgname string) string {
-	return variables.SecurityAssessmentRootDir + "/" + pkgname + variables.AttacksDir + variables.SourcePackageDir
+	return config.SecurityAssessmentRootDir + "/" + pkgname + variables.AttacksDir + variables.SourcePackageDir
 }
 
 // DisassemblePackageDirPath : Return the folder path where we store the "apktool -d" command result files (.smali).
 func DisassemblePackageDirPath(pkgname string) string {
-	return variables.SecurityAssessmentRootDir + "/" + pkgname + variables.AttacksDir + variables.DisassemblePackageDir
+	return config.SecurityAssessmentRootDir + "/" + pkgname + variables.AttacksDir + variables.DisassemblePackageDir
 }
 
 // DecompiledPackageDirPath : Return the folder path where we store the "jadx -d" command result files (.java).
 func DecompiledPackageDirPath(pkgname string) string {
-	return variables.SecurityAssessmentRootDir + "/" + pkgname + variables.AttacksDir + variables.DecompiledPackageDir
+	return config.SecurityAssessmentRootDir + "/" + pkgname + variables.AttacksDir + variables.DecompiledPackageDir
 }
 
 // DebugPkgDirPath : Return the folder path where we store the "apktool b" command result files (.b.apk).
 func DebugPkgDirPath(pkgname string) string {
-	return variables.SecurityAssessmentRootDir + "/" + pkgname + variables.AttacksDir + variables.DebuggablePackageDir
+	return config.SecurityAssessmentRootDir + "/" + pkgname + variables.AttacksDir + variables.DebuggablePackageDir
 }
 
 func createLeakageDir(pkgname string) {

--- a/attacks/insecurelogging.go
+++ b/attacks/insecurelogging.go
@@ -7,8 +7,6 @@ import (
 	"github.com/shosta/androSecTest/command"
 	"github.com/shosta/androSecTest/logging"
 	"github.com/shosta/androSecTest/terminal"
-
-	"github.com/shosta/androSecTest/variables"
 )
 
 // Get all the occurence of a string through a grep commanc and store it in a file.
@@ -60,8 +58,9 @@ func userInputStrInLog(pkgname string) {
 
 // Launch a logcat command and push the result to a file.
 func launchlogcat(pkgname string) {
-	logging.Println("Log svg : " + variables.SecurityAssessmentRootDir + "/" + pkgname + variables.AttacksDir + variables.InsecureLoggingDir + "/log.txt")
-	cmd := exec.Command("/bin/sh", "-c", "adb logcat > "+variables.SecurityAssessmentRootDir+"/"+pkgname+variables.AttacksDir+variables.InsecureLoggingDir+"/log.txt")
+	insecLoggingDirPath := InsecLoggingDirPath(pkgname)
+	logging.Println("Log svg : " + insecLoggingDirPath + "/log.txt")
+	cmd := exec.Command("/bin/sh", "-c", "adb logcat > "+insecLoggingDirPath+"/log.txt")
 
 	// Start command asynchronously
 	logging.PrintlnDebug("Launched logcat asynchronously.")

--- a/config/config_dev.go
+++ b/config/config_dev.go
@@ -1,0 +1,11 @@
+// +build dev
+
+package config
+
+// Development ready configuration const based on the build tags.
+const (
+	SecurityAssessmentRootDir = "/home/shosta/android/security"
+	IsDebug                   = true
+)
+
+var IsVerboseLogRequired = true

--- a/config/config_prod.go
+++ b/config/config_prod.go
@@ -1,0 +1,11 @@
+// +build prod
+
+package config
+
+// Production ready configuration const based on the build tags.
+const (
+	SecurityAssessmentRootDir = "/home/shosta/android/security"
+	IsDebug                   = false
+)
+
+var IsVerboseLogRequired = false

--- a/config/config_testing.go
+++ b/config/config_testing.go
@@ -1,0 +1,11 @@
+// +build testing
+
+package config
+
+// Testing ready configuration const based on the build tags.
+const (
+	SecurityAssessmentRootDir = "/home/shosta/android/security"
+	IsDebug                   = true
+)
+
+var IsVerboseLogRequired = true

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -4,26 +4,26 @@ package logging
 import (
 	"fmt"
 
-	"github.com/shosta/androSecTest/variables"
+	"github.com/shosta/androSecTest/config"
 )
 
 // PrintlnDebug :
 func PrintlnDebug(log string) {
-	if variables.IsDebug {
+	if config.IsDebug {
 		fmt.Println(Orange("[dbg:info] ") + log)
 	}
 }
 
 // PrintlnError :
 func PrintlnError(err interface{}) {
-	if variables.IsDebug {
+	if config.IsDebug {
 		fmt.Println(Red("[error] ") + fmt.Sprint(err))
 	}
 }
 
 // PrintlnVerbose : Print the log to the terminal if the
 func PrintlnVerbose(log string) {
-	if variables.IsVerboseLogRequired {
+	if config.IsVerboseLogRequired {
 		fmt.Println(log)
 	}
 }

--- a/variables/variables.go
+++ b/variables/variables.go
@@ -1,26 +1,27 @@
 package variables
 
-var IsVerboseLogRequired bool = false
-var IsDebug bool = true
+// Attacks folder names to have them gathered in one single place.
+const (
+	AttacksDir            = "/attacks"
+	SourcePackageDir      = "/sourcePackage"
+	UnzippedPackageDir    = "/unzippedPackage"
+	DisassemblePackageDir = "/disassemblePackage"
+	DecompiledPackageDir  = "/decompiledPackage"
+	LeakagesDir           = "/leakages"
+	DebuggablePackageDir  = "/debuggablePackage"
+	InsecureBackupDir     = "/insecureBackup"
+	InsecureLoggingDir    = "/insecureLogging"
+	InsecureStorageDir    = "/insecureStorage"
+)
 
-const SecurityAssessmentRootDir string = "/home/shosta/android/security"
-const AttacksDir string = "/attacks"
-const SourcePackageDir string = "/sourcePackage"
-const UnzippedPackageDir string = "/unzippedPackage"
-const DisassemblePackageDir string = "/disassemblePackage"
-const DecompiledPackageDir string = "/decompiledPackage"
-const LeakagesDir string = "/leakages"
-const DebuggablePackageDir string = "/debuggablePackage"
-const InsecureBackupDir string = "/insecureBackup"
-const InsecureLoggingDir string = "/insecureLogging"
-const InsecureStorageDir string = "/insecureStorage"
-
-
-const Header string = "\033[95m"
-const Blue string = "\033[94m"
-const Green string = "\033[92m"
-const Orange string = "\033[93m"
-const Red string = "\033[91m"
-const Endc string = "\033[0m"
-const Bold string = "\033[1m"
-const Underline string = "\033[4m"
+// Color const to display color on the terminal command.
+const (
+	Header    = "\033[95m"
+	Blue      = "\033[94m"
+	Green     = "\033[92m"
+	Orange    = "\033[93m"
+	Red       = "\033[91m"
+	Endc      = "\033[0m"
+	Bold      = "\033[1m"
+	Underline = "\033[4m"
+)

--- a/variables/variables.go
+++ b/variables/variables.go
@@ -15,7 +15,6 @@ const InsecureBackupDir string = "/insecureBackup"
 const InsecureLoggingDir string = "/insecureLogging"
 const InsecureStorageDir string = "/insecureStorage"
 
-var SecAssessmentPath string = "/home/shosta/android/security"
 
 const Header string = "\033[95m"
 const Blue string = "\033[94m"


### PR DESCRIPTION
I created 3 config files; dev, testing, prod.
Each file is taking care of th following const and var :
const SecurityAssessmentRootDir
const IsDebug
var IsVerboseLogRequired
regarding the build target.
To compile against a specific config, just run "go build -tags dev/testing/prod"